### PR TITLE
Modify the  toolchain of dshanpi A1

### DIFF
--- a/compiler_setup.cmake
+++ b/compiler_setup.cmake
@@ -1,6 +1,6 @@
 # have COMPILE_PREX
 if (NOT DEFINED CONFIG_COMPILE_PREX)
-    set(CONFIG_COMPILE_PREX "aarch64-none-linux-gnu-")
+	set(CONFIG_COMPILE_PREX "aarch64-none-linux-gnu-")
 endif()
 
 # Is cross compile?
@@ -47,13 +47,14 @@ if (IS_CROSS_COMPILE)
 
         get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PREFIX}/${CONFIG_COMPILE_PREX}" ABSOLUTE)
     elseif (PLATFORM_BOARD STREQUAL "DshanPi_A1")
-        get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PATH}/aarch64-none-linux-gnu-13.3-2024.04/bin" ABSOLUTE)
+	    #get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PREFIX}/usr/bin/" ABSOLUTE)
+	set(TOOLCHAIN_PREFIX "/usr/bin/")
         # TOOLCHAIN_PREFIX Check
-        if(NOT EXISTS "${TOOLCHAIN_PREFIX}")
-            message(FATAL_ERROR "Toolchain directory does not exist: ${TOOLCHAIN_PREFIX}")
-        endif()
+	if(NOT EXISTS "${TOOLCHAIN_PREFIX}")
+	    message(FATAL_ERROR "Toolchain directory does not exist: ${TOOLCHAIN_PREFIX}")
+	endif()
 
-        get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PREFIX}/${CONFIG_COMPILE_PREX}" ABSOLUTE)
+	#get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PREFIX}/" ABSOLUTE)
     else()
         message(FATAL_ERROR "Unsupported PLATFORM_BOARD for cross compilation: ${PLATFORM_BOARD}")
     endif()

--- a/compiler_setup.cmake
+++ b/compiler_setup.cmake
@@ -1,6 +1,6 @@
 # have COMPILE_PREX
 if (NOT DEFINED CONFIG_COMPILE_PREX)
-	set(CONFIG_COMPILE_PREX "aarch64-none-linux-gnu-")
+    set(CONFIG_COMPILE_PREX "aarch64-none-linux-gnu-")
 endif()
 
 # Is cross compile?
@@ -47,14 +47,14 @@ if (IS_CROSS_COMPILE)
 
         get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PREFIX}/${CONFIG_COMPILE_PREX}" ABSOLUTE)
     elseif (PLATFORM_BOARD STREQUAL "DshanPi_A1")
-	    #get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PREFIX}/usr/bin/" ABSOLUTE)
+	    #get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PATH}/aarch64-none-linux-gnu-13.3-2024.04/bin" ABSOLUTE)
 	set(TOOLCHAIN_PREFIX "/usr/bin/")
         # TOOLCHAIN_PREFIX Check
-	if(NOT EXISTS "${TOOLCHAIN_PREFIX}")
-	    message(FATAL_ERROR "Toolchain directory does not exist: ${TOOLCHAIN_PREFIX}")
-	endif()
+        if(NOT EXISTS "${TOOLCHAIN_PREFIX}")
+            message(FATAL_ERROR "Toolchain directory does not exist: ${TOOLCHAIN_PREFIX}")
+        endif()
 
-	#get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PREFIX}/" ABSOLUTE)
+	#get_filename_component(TOOLCHAIN_PREFIX "${TOOLCHAIN_PREFIX}/${CONFIG_COMPILE_PREX}" ABSOLUTE)
     else()
         message(FATAL_ERROR "Unsupported PLATFORM_BOARD for cross compilation: ${PLATFORM_BOARD}")
     endif()


### PR DESCRIPTION
Since the DshanPI A1 runs the ArmBian Ubuntu 24 LTS system, there is no need for cross-compilation; it can be compiled locally, so you can directly use gcc and g++ in the /usr/bin directory.