### PR TITLE
fix(uart): add NULL check for rx_cb in IRQ handlers

### DIFF
--- a/tuyaos_adapter/src/tkl_uart.c
+++ b/tuyaos_adapter/src/tkl_uart.c
@@ -124,7 +124,9 @@ static void *__irq_handler(void *arg)
         FD_SET(uart_dev->fd, &readfd);
         select(uart_dev->fd + 1, &readfd, NULL, NULL, NULL);
         if (FD_ISSET(uart_dev->fd, &readfd)){
-            uart_dev->rx_cb(0);
+            if (uart_dev->rx_cb) {
+                uart_dev->rx_cb(0);
+            }
         }
     }
 }
@@ -141,7 +143,9 @@ static void *__uart_irq_handler(void *arg)
         FD_SET(uart_dev->fd, &readfd);
         select(uart_dev->fd + 1, &readfd, NULL, NULL, NULL);
         if (FD_ISSET(uart_dev->fd, &readfd)) {
-            uart_dev->rx_cb(0);
+            if (uart_dev->rx_cb) {
+                uart_dev->rx_cb(0);
+            }
         }
     }
 }
@@ -160,7 +164,9 @@ static void *__udp_irq_handler(void *arg)
             ssize_t readlen = recvfrom(uart_dev->fd, uart_dev->readbuff, sizeof(uart_dev->readbuff), 0, NULL, 0);
             for (int i = 0; i < readlen; i++) {
                 uart_dev->readchar = uart_dev->readbuff[i];
-                uart_dev->rx_cb(1);
+                if (uart_dev->rx_cb) {
+                    uart_dev->rx_cb(1);
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

Running the camera demo on Linux causes a segmentation fault shortly after startup:

```
[01-05 18:21:19 ty D][tal_thread.c:248] Thread:tuya_p2p_listen Exec Start. Set to Running Stat
listen task start
[1]    3928835 segmentation fault (core dumped)  ./camera_demo_QIO_1.0.0.bin
```

## Root Cause

GDB backtrace shows the crash is a **NULL function pointer call** in the UART IRQ handler thread:

```
Thread 5 (crashed):
#0  0x0000000000000000 in ?? ()
#1  __irq_handler (tkl_uart.c:127)
```

The UART IRQ handler threads (`__irq_handler`, `__uart_irq_handler`, `__udp_irq_handler`) are started by `tkl_uart_init()` **before** `tkl_uart_rx_irq_cb_reg()` is called to register the `rx_cb` callback. The initialization sequence in `tal_uart.c` is:

1. `tkl_uart_init()` — creates the IRQ handler thread, which immediately starts watching the fd via `select()`
2. …ring buffer / semaphore setup…
3. `tkl_uart_rx_irq_cb_reg()` — finally sets `rx_cb`

If the fd becomes readable during this window (e.g. stdin data, terminal input), the handler calls `uart_dev->rx_cb(0)` while `rx_cb` is still `NULL` → **segfault**.

## Fix

Add NULL guards before invoking `rx_cb` in all three IRQ handler functions (`__irq_handler`, `__uart_irq_handler`, `__udp_irq_handler`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)